### PR TITLE
Feat: 일정 생성기 저장 시 frames, mapping JSON 배열 저장, 웹url 저장 기능 추가

### DIFF
--- a/src/main/java/Capstone/AutoScheduler/global/converter/GeneratorConverter.java
+++ b/src/main/java/Capstone/AutoScheduler/global/converter/GeneratorConverter.java
@@ -14,6 +14,10 @@ public class GeneratorConverter {
         return Generator.builder()
                 .generatorTitle(request.getGeneratorTitle())
                 .generatorDetail(request.getGeneratorDetail())
+                .frames(request.getFrames())
+                .mapping(request.getMapping())
+                .sourceType(request.getSourceType())
+                .webUrl(request.getWebUrl())
                 .build();
     }
 
@@ -21,9 +25,14 @@ public class GeneratorConverter {
         return GeneratorResponseDTO.CreateGeneratorResultDTO.builder()
                 .generatorId(generator.getGeneratorId())
                 .memberId(generator.getMember().getMemberId())
-                .sourceId(generator.getSource().getSourceId())
+                .memberName(generator.getMember().getName())
+                //.sourceId(generator.getSource().getSourceId())
+                .sourceType(generator.getSourceType())
                 .generatorTitle(generator.getGeneratorTitle())
                 .generatorDetail(generator.getGeneratorDetail())
+                .frames(generator.getFrames())
+                .mapping(generator.getMapping())
+                .webUrl(generator.getWebUrl())
                 .build();
     }
 
@@ -31,9 +40,14 @@ public class GeneratorConverter {
         return GeneratorResponseDTO.GeneratorDTO.builder()
                 .generatorId(generator.getGeneratorId())
                 .memberId(generator.getMember().getMemberId())
-                .sourceId(generator.getSource().getSourceId())
+                .memberName(generator.getMember().getName())
+                //.sourceId(generator.getSource().getSourceId())
+                .sourceType(generator.getSourceType())
                 .generatorTitle(generator.getGeneratorTitle())
                 .generatorDetail(generator.getGeneratorDetail())
+                .frames(generator.getFrames())
+                .mapping(generator.getMapping())
+                .webUrl(generator.getWebUrl())
                 .build();
     }
 
@@ -41,9 +55,14 @@ public class GeneratorConverter {
         return GeneratorResponseDTO.GeneratorPreviewDTO.builder()
                 .generatorId(generator.getGeneratorId())
                 .memberId(generator.getMember().getMemberId())
-                .sourceId(generator.getSource().getSourceId())
+                .memberName(generator.getMember().getName())
+                //.sourceId(generator.getSource().getSourceId())
+                .sourceType(generator.getSourceType())
                 .generatorTitle(generator.getGeneratorTitle())
                 .generatorDetail(generator.getGeneratorDetail())
+                .frames(generator.getFrames())
+                .mapping(generator.getMapping())
+                .webUrl(generator.getWebUrl())
                 .build();
     }
 

--- a/src/main/java/Capstone/AutoScheduler/global/converter/JsonConverter.java
+++ b/src/main/java/Capstone/AutoScheduler/global/converter/JsonConverter.java
@@ -1,0 +1,36 @@
+package Capstone.AutoScheduler.global.converter;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+@Converter
+public class JsonConverter implements AttributeConverter<List<Map<String, Object>>, String> {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Override
+    public String convertToDatabaseColumn(List<Map<String, Object>> attribute) {
+        try {
+            return objectMapper.writeValueAsString(attribute);
+        } catch (JsonProcessingException e) {
+            throw new IllegalArgumentException("JSON 직렬화 오류", e);
+        }
+    }
+
+    @Override
+    public List<Map<String, Object>> convertToEntityAttribute(String dbData) {
+        try {
+            return objectMapper.readValue(dbData, new TypeReference<List<Map<String, Object>>>() {});
+        } catch (IOException e) {
+            throw new IllegalArgumentException("JSON 역직렬화 오류", e);
+        }
+    }
+}
+

--- a/src/main/java/Capstone/AutoScheduler/global/domain/entity/Generator.java
+++ b/src/main/java/Capstone/AutoScheduler/global/domain/entity/Generator.java
@@ -1,12 +1,16 @@
 package Capstone.AutoScheduler.global.domain.entity;
 
 
+import Capstone.AutoScheduler.global.converter.JsonConverter;
 import Capstone.AutoScheduler.global.domain.common.BaseEntity;
+import Capstone.AutoScheduler.global.domain.enums.TypeSource;
 import jakarta.persistence.*;
 import lombok.*;
 
+
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 @Entity
 @Getter
@@ -25,9 +29,13 @@ public class Generator extends BaseEntity {
     @JoinColumn(name = "member_id", nullable = false)
     private Member member;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "source_id", nullable = false)
-    private Source source;
+//    @ManyToOne(fetch = FetchType.LAZY)
+//    @JoinColumn(name = "source_id", nullable = false)
+//    private Source source;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "source_type", nullable = false, columnDefinition = "varchar(256)")
+    private TypeSource sourceType;
 
     @Column(name = "generator_title", nullable = false, columnDefinition = "varchar(256)")
     private String generatorTitle;
@@ -35,6 +43,25 @@ public class Generator extends BaseEntity {
     @Column(name = "generator_detail", nullable = false, columnDefinition = "varchar(256)")
     private String generatorDetail;
 
+//    // frames 배열(string)
+//    @Column(name = "frames", nullable = false, columnDefinition = "TEXT")
+//    private String frames;
+//    // mapping 배열(string)
+//    @Column(name = "mapping", nullable = false, columnDefinition = "TEXT")
+//    private String mapping;
+
+    // JSON 데이터를 문자열로 저장
+    @Convert(converter = JsonConverter.class)
+    @Column(name = "frames", nullable = false, columnDefinition = "TEXT")
+    private List<Map<String, Object>> frames;
+
+    @Convert(converter = JsonConverter.class)
+    @Column(name = "mapping", nullable = false, columnDefinition = "TEXT")
+    private List<Map<String, Object>> mapping;
+
+    // SourceType web일 경우 해당 URL
+    @Column(name = "webUrl", nullable = true, columnDefinition = "varchar(512)")
+    private String webUrl;
 
     // 해당 일정 생성기로 생성한 Event 리스트
     @OneToMany(mappedBy = "generator", cascade = CascadeType.ALL, orphanRemoval = true)

--- a/src/main/java/Capstone/AutoScheduler/global/service/GeneratorService/GeneratorCommandService.java
+++ b/src/main/java/Capstone/AutoScheduler/global/service/GeneratorService/GeneratorCommandService.java
@@ -5,7 +5,7 @@ import Capstone.AutoScheduler.global.web.dto.Generator.GeneratorRequestDTO;
 
 public interface GeneratorCommandService {
     // 일정 생성기 저장
-    Generator createGenerator(Long memberId, Long sourceId, GeneratorRequestDTO.CreateGeneratorRequestDTO request);
+    Generator createGenerator(Long memberId, GeneratorRequestDTO.CreateGeneratorRequestDTO request);
 
 
 

--- a/src/main/java/Capstone/AutoScheduler/global/service/GeneratorService/GeneratorCommandServiceImpl.java
+++ b/src/main/java/Capstone/AutoScheduler/global/service/GeneratorService/GeneratorCommandServiceImpl.java
@@ -25,13 +25,13 @@ public class GeneratorCommandServiceImpl implements GeneratorCommandService {
     private final BookmarkCommandService bookmarkCommandService;
 
     @Override
-    public Generator createGenerator(Long memberId, Long sourceId, GeneratorRequestDTO.CreateGeneratorRequestDTO request) {
+    public Generator createGenerator(Long memberId, GeneratorRequestDTO.CreateGeneratorRequestDTO request) {
         Generator newGenerator = GeneratorConverter.toGenerator(request);
         Member getMember = memberRepository.findById(memberId).orElseThrow(() -> new IllegalArgumentException("해당 멤버가 존재하지 않습니다."));
         newGenerator.setMember(getMember);
 
-        Source getSource = sourceRepository.findById(sourceId).orElseThrow(() -> new IllegalArgumentException("해당 소스가 존재하지 않습니다."));
-        newGenerator.setSource(getSource);
+//        Source getSource = sourceRepository.findById(sourceId).orElseThrow(() -> new IllegalArgumentException("해당 소스가 존재하지 않습니다."));
+//        newGenerator.setSource(getSource);
 
         Generator savedGenerator = generateRepository.save(newGenerator);
 

--- a/src/main/java/Capstone/AutoScheduler/global/web/controller/EventController.java
+++ b/src/main/java/Capstone/AutoScheduler/global/web/controller/EventController.java
@@ -16,6 +16,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @RestController
@@ -77,5 +78,30 @@ public class EventController {
         Event event = eventQueryService.getEvent(memberId, eventId);
         return ApiResponse.onSuccess(SuccessStatus.EVENT_OK, EventConverter.toMemberEventPreviewDTO(event));
     }
+
+//    @PostMapping("/event/multipleEvents/{memberId}/{generatorId}")
+//    @Operation(summary = "자동 생성된 모든 일정 저장하기", description = "일정 생성기에서 자동 생성된 개별 일정을 모두 저장합니다.")
+//    public ApiResponse<List<EventResponseDTO.CreateEventResultDTO>> createIndividualEventsFromList(
+//            @PathVariable Long memberId,
+//            @PathVariable Long generatorId,
+//            @RequestBody List<EventRequestDTO.CreateEventRequestDTO> multiEventRequests) {
+//
+//        // 저장된 이벤트 결과를 담을 리스트
+//        List<EventResponseDTO.CreateEventResultDTO> createdEvents = new ArrayList<>();
+//
+//        // 요청된 각 일정 데이터를 처리
+//        for (EventRequestDTO.CreateEventRequestDTO request : multiEventRequests) {
+//            // EventCommandService를 통해 개별 이벤트 생성
+//            Event newEvent = eventCommandService.createIndividualEventFromList(memberId, generatorId, request);
+//
+//            // 생성된 이벤트를 DTO로 변환하여 결과 리스트에 추가
+//            createdEvents.add(EventConverter.toCreateResultDTO(newEvent));
+//        }
+//
+//        // 성공 응답 반환
+//        return ApiResponse.onSuccess(SuccessStatus.EVENT_OK, createdEvents);
+//    }
+
+
 
 }

--- a/src/main/java/Capstone/AutoScheduler/global/web/controller/GeneratorController.java
+++ b/src/main/java/Capstone/AutoScheduler/global/web/controller/GeneratorController.java
@@ -38,10 +38,10 @@ public class GeneratorController {
     @Operation(summary = "일정 생성기 생성하기", description = "일정 생성기를 생성합니다.")
     public ApiResponse<GeneratorResponseDTO.CreateGeneratorResultDTO> generatorCreate(
             @RequestParam Long memberId,
-            @RequestParam Long sourceId,
+            //@RequestParam Long sourceId,
             @RequestBody GeneratorRequestDTO.CreateGeneratorRequestDTO request
     ){
-        Generator newGenerator = generatorCommandService.createGenerator(memberId, sourceId, request);
+        Generator newGenerator = generatorCommandService.createGenerator(memberId, request);
         return ApiResponse.onSuccess(
                 SuccessStatus.GENERATOR_OK,
                 GeneratorConverter.toCreateResultDTO(newGenerator)

--- a/src/main/java/Capstone/AutoScheduler/global/web/dto/Frame/FrameRequestDTO.java
+++ b/src/main/java/Capstone/AutoScheduler/global/web/dto/Frame/FrameRequestDTO.java
@@ -1,0 +1,36 @@
+package Capstone.AutoScheduler.global.web.dto.Frame;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class FrameRequestDTO {
+    private Long id;
+    private List<String> title;
+    private List<DateDetailDTO> date;
+    private List<DetailDTO> detail;
+
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class DateDetailDTO {
+        private String type;
+        private Long startBubbleId;
+        private List<String> childOperations;
+    }
+
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class DetailDTO {
+        private String type;
+        private Long startBubbleId;
+        private List<String> childOperations;
+    }
+}
+

--- a/src/main/java/Capstone/AutoScheduler/global/web/dto/Frame/FrameResponseDTO.java
+++ b/src/main/java/Capstone/AutoScheduler/global/web/dto/Frame/FrameResponseDTO.java
@@ -1,0 +1,4 @@
+package Capstone.AutoScheduler.global.web.dto.Frame;
+
+public class FrameResponseDTO {
+}

--- a/src/main/java/Capstone/AutoScheduler/global/web/dto/Generator/GeneratorRequestDTO.java
+++ b/src/main/java/Capstone/AutoScheduler/global/web/dto/Generator/GeneratorRequestDTO.java
@@ -1,9 +1,13 @@
 package Capstone.AutoScheduler.global.web.dto.Generator;
 
+import Capstone.AutoScheduler.global.domain.enums.TypeSource;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.util.List;
+import java.util.Map;
 
 public class GeneratorRequestDTO {
 
@@ -14,5 +18,12 @@ public class GeneratorRequestDTO {
     public static class CreateGeneratorRequestDTO {
         private String generatorTitle;
         private String generatorDetail;
+        //private String frames;
+        //private String mapping;
+        // JSON 데이터를 리스트로 처리
+        private List<Map<String, Object>> frames;
+        private List<Map<String, Object>> mapping;
+        private TypeSource sourceType;
+        private String webUrl;
     }
 }

--- a/src/main/java/Capstone/AutoScheduler/global/web/dto/Generator/GeneratorResponseDTO.java
+++ b/src/main/java/Capstone/AutoScheduler/global/web/dto/Generator/GeneratorResponseDTO.java
@@ -1,11 +1,13 @@
 package Capstone.AutoScheduler.global.web.dto.Generator;
 
+import Capstone.AutoScheduler.global.domain.enums.TypeSource;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.util.List;
+import java.util.Map;
 
 public class GeneratorResponseDTO {
 
@@ -16,9 +18,17 @@ public class GeneratorResponseDTO {
     public static class CreateGeneratorResultDTO {
         Long generatorId;
         Long memberId;
-        Long sourceId;
+        String memberName;
+        //Long sourceId;
+        TypeSource sourceType;
         String generatorTitle;
         String generatorDetail;
+        //String frames;
+        //String mapping;
+        // JSON 데이터를 List<Map<String, Object>>로 처리
+        List<Map<String, Object>> frames;
+        List<Map<String, Object>> mapping;
+        String webUrl;
     }
 
     @Getter
@@ -28,9 +38,17 @@ public class GeneratorResponseDTO {
     public static class GeneratorDTO {
         Long generatorId;
         Long memberId;
-        Long sourceId;
+        String memberName;
+        //Long sourceId;
+        TypeSource sourceType;
         String generatorTitle;
         String generatorDetail;
+        //String frames;
+        //String mapping;
+        // JSON 데이터를 List<Map<String, Object>>로 처리
+        List<Map<String, Object>> frames;
+        List<Map<String, Object>> mapping;
+        String webUrl;
     }
 
     @Getter
@@ -40,9 +58,16 @@ public class GeneratorResponseDTO {
     public static class GeneratorPreviewDTO {
         Long generatorId;
         Long memberId;
-        Long sourceId;
+        String memberName;
+        TypeSource sourceType;
         String generatorTitle;
         String generatorDetail;
+        //String frames;
+        //String mapping;
+        // JSON 데이터를 List<Map<String, Object>>로 처리
+        List<Map<String, Object>> frames;
+        List<Map<String, Object>> mapping;
+        String webUrl;
     }
 
     @Builder


### PR DESCRIPTION
## #️⃣연관된 이슈
> #90 

## 📝작업 내용
> - 일정 생성기 저장 시, 제공된 JSON 형태의 frames, mapping 배열 string으로 저장하도록 구현
> - SourceType WEB일 경우 url 정보 저장할 수 있도록 구현

## 🔎코드 설명 및 참고 사항
> Generator 엔티티 저장 항목
- 일정 생성기 만든 유저 (memberId)
- 생성기 이름 
- 생성기 설명
- 생성 일자
- frames 배열 (json -> string)
- mapping 배열 (json -> string)
- sourceType (PDF, WEB)
- web URL

## 💬리뷰 요구사항
>
