### PR TITLE
Feat: 일정 생성기로부터 자동 생성된 모든 일정 저장하는 API 기능 구현

### DIFF
--- a/src/main/java/Capstone/AutoScheduler/global/config/SecurityConfig.java
+++ b/src/main/java/Capstone/AutoScheduler/global/config/SecurityConfig.java
@@ -25,7 +25,7 @@ public class SecurityConfig {
                                 .requestMatchers("/member/sign-up", "/member/sign-in").permitAll()
                                 .requestMatchers("/member/**").permitAll()
                                 // Event 관련 접근
-                                .requestMatchers("/event/", "/event/{eventId}", "/event/member/{memberId}", "/event/member/{memberId}/event/{eventId}", "/event/member/{memberId}/date/{date}").permitAll()
+                                .requestMatchers("/event/", "/event/{eventId}", "/event/member/{memberId}", "/event/member/{memberId}/event/{eventId}", "/event/member/{memberId}/date/{date}", "/event/multipleEvents/{memberId}/{generatorId}").permitAll()
                                 // Generator 관련 접근
                                 .requestMatchers("/generator/", "/generator/{generatorId}").permitAll()
                                 // Bookmark 관련 접근

--- a/src/main/java/Capstone/AutoScheduler/global/converter/EventConverter.java
+++ b/src/main/java/Capstone/AutoScheduler/global/converter/EventConverter.java
@@ -23,12 +23,14 @@ public class EventConverter {
         return EventResponseDTO.CreateEventResultDTO.builder()
                 .eventId(event.getEventId())
                 .memberId(event.getMember().getMemberId())
+                .generatorId(event.getGenerator() != null ? event.getGenerator().getGeneratorId() : null) // generatorId 추가
                 .eventTitle(event.getEventTitle())
                 .eventBody(event.getEventBody())
                 .startDate(event.getStartDate())
                 .endDate(event.getEndDate())
                 .build();
     }
+
 
     public static EventResponseDTO.UpdateEventResultDTO UpdateEventResultDTO(Event event) {
         return EventResponseDTO.UpdateEventResultDTO.builder()
@@ -43,6 +45,7 @@ public class EventConverter {
     public static EventResponseDTO.MemberEventPreviewDTO toMemberEventPreviewDTO(Event event) {
         return EventResponseDTO.MemberEventPreviewDTO.builder()
                 .memberId(event.getMember().getMemberId())
+                .generatorId(event.getGenerator() != null ? event.getGenerator().getGeneratorId() : null) // generatorId 추가
                 .eventId(event.getEventId())
                 .eventTitle(event.getEventTitle())
                 .eventBody(event.getEventBody())

--- a/src/main/java/Capstone/AutoScheduler/global/service/EventService/EventCommandService.java
+++ b/src/main/java/Capstone/AutoScheduler/global/service/EventService/EventCommandService.java
@@ -8,4 +8,5 @@ public interface EventCommandService {
     Event createEvent(Long memberId, EventRequestDTO.CreateEventRequestDTO request);
     Event updateEvent(Long memberId, Long eventId, EventRequestDTO.UpdateEventDTO request);
     void deleteEvent(Long memberId, Long eventId);
+    Event createEventWithGenerator(Long memberId, Long generatorId, EventRequestDTO.CreateEventRequestDTO request);
 }

--- a/src/main/java/Capstone/AutoScheduler/global/service/EventService/EventCommandServiceImpl.java
+++ b/src/main/java/Capstone/AutoScheduler/global/service/EventService/EventCommandServiceImpl.java
@@ -2,9 +2,11 @@ package Capstone.AutoScheduler.global.service.EventService;
 
 import Capstone.AutoScheduler.global.converter.EventConverter;
 import Capstone.AutoScheduler.global.domain.entity.Event;
+import Capstone.AutoScheduler.global.domain.entity.Generator;
 import Capstone.AutoScheduler.global.domain.entity.Member;
 import Capstone.AutoScheduler.global.repository.EventRepository;
 import Capstone.AutoScheduler.global.repository.MemberRepository;
+import Capstone.AutoScheduler.global.repository.GeneratorRepository;
 import Capstone.AutoScheduler.global.web.dto.Event.EventRequestDTO;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -19,36 +21,67 @@ public class EventCommandServiceImpl implements EventCommandService {
 
     private final MemberRepository memberRepository;
     private final EventRepository eventRepository;
+    private final GeneratorRepository generatorRepository;
 
     @Override
     public Event createEvent(Long memberId, EventRequestDTO.CreateEventRequestDTO request) {
+        Member member = findMemberById(memberId);
 
         Event newEvent = EventConverter.toEvent(request);
-        Member getMember = memberRepository.findById(memberId)
-                .orElseThrow(() -> new IllegalArgumentException("해당 멤버가 존재하지 않습니다."));
-        newEvent.setMember(getMember);
+        newEvent.setMember(member);
 
         Event savedEvent = eventRepository.save(newEvent);
+        log.info("Event created: {}", savedEvent);
         return savedEvent;
     }
 
     @Override
     public Event updateEvent(Long memberId, Long eventId, EventRequestDTO.UpdateEventDTO request) {
-        Member getMember = memberRepository.findById(memberId)
-                .orElseThrow(() -> new IllegalArgumentException("해당 멤버가 존재하지 않습니다."));
+        Member member = findMemberById(memberId);
 
-        Event updateEvent = eventRepository.findById(eventId).get();
-        updateEvent.update(request);
-        return updateEvent;
+        Event event = eventRepository.findById(eventId)
+                .orElseThrow(() -> new IllegalArgumentException("Event not found. ID: " + eventId));
+
+        event.update(request);
+        log.info("Event updated: {}", event);
+        return event;
     }
 
     @Override
     public void deleteEvent(Long memberId, Long eventId) {
-        Member getMember = memberRepository.findById(memberId)
-                .orElseThrow(() -> new IllegalArgumentException("해당 멤버가 존재하지 않습니다."));
+        Member member = findMemberById(memberId);
 
-        Event deleteEvent = eventRepository.findById(eventId).get();
-        eventRepository.delete(deleteEvent);
+        Event event = eventRepository.findById(eventId)
+                .orElseThrow(() -> new IllegalArgumentException("Event not found. ID: " + eventId));
+
+        eventRepository.delete(event);
+        log.info("Event deleted: {}", event);
     }
+
+    @Override
+    public Event createEventWithGenerator(Long memberId, Long generatorId, EventRequestDTO.CreateEventRequestDTO request) {
+        Member member = findMemberById(memberId);
+        Generator generator = findGeneratorById(generatorId);
+
+        Event newEvent = EventConverter.toEvent(request);
+        newEvent.setMember(member);
+        newEvent.setGenerator(generator);
+
+        Event savedEvent = eventRepository.save(newEvent);
+        log.info("Event created with generator: {}", savedEvent);
+        return savedEvent;
+    }
+
+
+    private Member findMemberById(Long memberId) {
+        return memberRepository.findById(memberId)
+                .orElseThrow(() -> new IllegalArgumentException("Member not found. ID: " + memberId));
+    }
+
+    private Generator findGeneratorById(Long generatorId) {
+        return generatorRepository.findById(generatorId)
+                .orElseThrow(() -> new IllegalArgumentException("Generator not found. ID: " + generatorId));
+    }
+
 
 }

--- a/src/main/java/Capstone/AutoScheduler/global/web/controller/EventController.java
+++ b/src/main/java/Capstone/AutoScheduler/global/web/controller/EventController.java
@@ -79,28 +79,19 @@ public class EventController {
         return ApiResponse.onSuccess(SuccessStatus.EVENT_OK, EventConverter.toMemberEventPreviewDTO(event));
     }
 
-//    @PostMapping("/event/multipleEvents/{memberId}/{generatorId}")
-//    @Operation(summary = "자동 생성된 모든 일정 저장하기", description = "일정 생성기에서 자동 생성된 개별 일정을 모두 저장합니다.")
-//    public ApiResponse<List<EventResponseDTO.CreateEventResultDTO>> createIndividualEventsFromList(
-//            @PathVariable Long memberId,
-//            @PathVariable Long generatorId,
-//            @RequestBody List<EventRequestDTO.CreateEventRequestDTO> multiEventRequests) {
-//
-//        // 저장된 이벤트 결과를 담을 리스트
-//        List<EventResponseDTO.CreateEventResultDTO> createdEvents = new ArrayList<>();
-//
-//        // 요청된 각 일정 데이터를 처리
-//        for (EventRequestDTO.CreateEventRequestDTO request : multiEventRequests) {
-//            // EventCommandService를 통해 개별 이벤트 생성
-//            Event newEvent = eventCommandService.createIndividualEventFromList(memberId, generatorId, request);
-//
-//            // 생성된 이벤트를 DTO로 변환하여 결과 리스트에 추가
-//            createdEvents.add(EventConverter.toCreateResultDTO(newEvent));
-//        }
-//
-//        // 성공 응답 반환
-//        return ApiResponse.onSuccess(SuccessStatus.EVENT_OK, createdEvents);
-//    }
+    // 자동 생성된 모든 일정 저장하기
+    @PostMapping("/multipleEvents/{memberId}/{generatorId}")
+    @Operation(summary = "자동 생성된 모든 일정 저장하기", description = "일정 생성기에서 자동 생성된 개별 일정을 모두 저장합니다.")
+    public ApiResponse<List<EventResponseDTO.CreateEventResultDTO>> createMultipleEvents(@RequestParam Long memberId, @RequestParam Long generatorId,
+                                                                                         @RequestBody EventRequestDTO.CreateMultipleEventsRequestDTO request) {
+        List<EventResponseDTO.CreateEventResultDTO> createdEvents = new ArrayList<>();
+
+        for (EventRequestDTO.CreateEventRequestDTO eventRequest : request.getEvents()) {
+            Event newEvent = eventCommandService.createEventWithGenerator(memberId, generatorId, eventRequest);
+            createdEvents.add(EventConverter.toCreateResultDTO(newEvent));
+        }
+        return ApiResponse.onSuccess(SuccessStatus.EVENT_OK, createdEvents);
+    }
 
 
 

--- a/src/main/java/Capstone/AutoScheduler/global/web/dto/Event/EventRequestDTO.java
+++ b/src/main/java/Capstone/AutoScheduler/global/web/dto/Event/EventRequestDTO.java
@@ -3,6 +3,7 @@ package Capstone.AutoScheduler.global.web.dto.Event;
 import lombok.*;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 public class EventRequestDTO {
 
@@ -29,5 +30,15 @@ public class EventRequestDTO {
         private LocalDateTime startDate;
         private LocalDateTime endDate;
     }
+
+    @Getter
+    @Setter
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class CreateMultipleEventsRequestDTO {
+        private List<CreateEventRequestDTO> events; // 여러 이벤트 생성 요청
+    }
+
 
 }

--- a/src/main/java/Capstone/AutoScheduler/global/web/dto/Event/EventResponseDTO.java
+++ b/src/main/java/Capstone/AutoScheduler/global/web/dto/Event/EventResponseDTO.java
@@ -18,6 +18,7 @@ public class EventResponseDTO {
     public static class CreateEventResultDTO {
         Long eventId;
         Long memberId;
+        Long generatorId;
         String eventTitle;
         String eventBody;
         LocalDateTime startDate;
@@ -42,6 +43,7 @@ public class EventResponseDTO {
     @AllArgsConstructor
     public static class MemberEventPreviewDTO {
         Long memberId;
+        Long generatorId;
         Long eventId;
         String eventTitle;
         String eventBody;


### PR DESCRIPTION
## #️⃣연관된 이슈
> #90 
## 📝작업 내용
> 일정 생성기로부터 자동 생성된 모든 일정 저장하는 API 기능 구현

## 🔎코드 설명 및 참고 사항
> 일정 생성기로부터 자동 생성된 모든 일정 저장하는 API 기능 구현
- JSON 형태로 받은 모든 일정 배열을 각각 개별 일정으로 저장
- 어떤 일정 생성기로부터 생성된 일정인지 확인을 위해 일정 생성기 id값 입력 필요

## 💬리뷰 요구사항
>
