### PR TITLE
Refactor: 자동 생성된 모든 일정 저장하는 API에서 RequestParam으로 받는 부분 PathVariable로 변경(멤버, 일정생성기 Id)

### DIFF
--- a/src/main/java/Capstone/AutoScheduler/global/web/controller/EventController.java
+++ b/src/main/java/Capstone/AutoScheduler/global/web/controller/EventController.java
@@ -82,7 +82,7 @@ public class EventController {
     // 자동 생성된 모든 일정 저장하기
     @PostMapping("/multipleEvents/{memberId}/{generatorId}")
     @Operation(summary = "자동 생성된 모든 일정 저장하기", description = "일정 생성기에서 자동 생성된 개별 일정을 모두 저장합니다.")
-    public ApiResponse<List<EventResponseDTO.CreateEventResultDTO>> createMultipleEvents(@RequestParam Long memberId, @RequestParam Long generatorId,
+    public ApiResponse<List<EventResponseDTO.CreateEventResultDTO>> createMultipleEvents(@PathVariable Long memberId, @PathVariable Long generatorId,
                                                                                          @RequestBody EventRequestDTO.CreateMultipleEventsRequestDTO request) {
         List<EventResponseDTO.CreateEventResultDTO> createdEvents = new ArrayList<>();
 


### PR DESCRIPTION
## #️⃣연관된 이슈
> #90

## 📝작업 내용
> 자동 생성된 모든 일정 저장하는 API에서 RequestParam으로 받는 부분 PathVariable로 변경(멤버, 일정생성기 Id)

## 🔎코드 설명 및 참고 사항
> 자동 생성된 모든 일정 저장하는 API에서 RequestParam으로 받는 부분 PathVariable로 변경(멤버, 일정생성기 Id)

## 💬리뷰 요구사항
>
