### PR TITLE
Refactor: 사용자가 일정 생성기 북마크를 삭제하는 API 기능 수정

### DIFF
--- a/src/main/java/Capstone/AutoScheduler/global/config/SecurityConfig.java
+++ b/src/main/java/Capstone/AutoScheduler/global/config/SecurityConfig.java
@@ -34,7 +34,7 @@ public class SecurityConfig {
                                 // Generator 관련 접근
                                 .requestMatchers("/generator/", "/generator/{generatorId}", "/generator/list/{memberId}").permitAll()
                                 // Bookmark 관련 접근
-                                .requestMatchers("/bookmark/add/{memberId}/{generatorId}", "/bookmark/delete/{bookmarkId}" ).permitAll()
+                                .requestMatchers("/bookmark/add/{memberId}/{generatorId}", "/bookmark/delete/{memberId}/{generatorId}" ).permitAll()
                                 // Crawling 관련 접근
                                 .requestMatchers("/crawl", "/crawl-with-login").permitAll() // /crawl 경로 접근 허용
                                 // 기타 관련 접근

--- a/src/main/java/Capstone/AutoScheduler/global/domain/entity/Generator.java
+++ b/src/main/java/Capstone/AutoScheduler/global/domain/entity/Generator.java
@@ -8,6 +8,7 @@ import jakarta.persistence.*;
 import lombok.*;
 
 
+import javax.net.ssl.SSLSession;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -74,4 +75,13 @@ public class Generator extends BaseEntity {
         this.events.add(event);
         event.setGenerator(this);
     }
+
+    public Bookmark getBookmarkByMember(Long memberId) {
+        return this.bookmarkList.stream()
+                .filter(bookmark -> bookmark.getMember().getMemberId().equals(memberId))
+                .findFirst()
+                .orElse(null); // 해당 멤버의 북마크가 없을 경우 null 반환
+    }
+
+
 }

--- a/src/main/java/Capstone/AutoScheduler/global/repository/BookmarkRepository.java
+++ b/src/main/java/Capstone/AutoScheduler/global/repository/BookmarkRepository.java
@@ -21,4 +21,7 @@ public interface BookmarkRepository extends JpaRepository<Bookmark, Long> {
     @Query("SELECT b.generator.generatorId FROM Bookmark b WHERE b.member.memberId = :memberId")
     List<Long> findBookmarkedGeneratorIdsByMemberId(@Param("memberId") Long memberId);
 
+    @Query("SELECT b.id FROM Bookmark b WHERE b.member.id = :memberId AND b.generator.generatorId = :generatorId")
+    Long findBookmarkIdByMemberAndGenerator(@Param("memberId") Long memberId, @Param("generatorId") Long generatorId);
+
 }

--- a/src/main/java/Capstone/AutoScheduler/global/service/BookmarkService/BookmarkQueryService.java
+++ b/src/main/java/Capstone/AutoScheduler/global/service/BookmarkService/BookmarkQueryService.java
@@ -1,0 +1,5 @@
+package Capstone.AutoScheduler.global.service.BookmarkService;
+
+public interface BookmarkQueryService {
+    Long findBookmarkIdByMemberAndGenerator(Long memberId, Long generatorId);
+}

--- a/src/main/java/Capstone/AutoScheduler/global/service/BookmarkService/BookmarkQueryServiceImpl.java
+++ b/src/main/java/Capstone/AutoScheduler/global/service/BookmarkService/BookmarkQueryServiceImpl.java
@@ -1,0 +1,20 @@
+package Capstone.AutoScheduler.global.service.BookmarkService;
+
+import Capstone.AutoScheduler.global.repository.BookmarkRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+@Slf4j
+public class BookmarkQueryServiceImpl implements BookmarkQueryService {
+    private final BookmarkRepository bookmarkRepository;
+
+    @Override
+    public Long findBookmarkIdByMemberAndGenerator(Long memberId, Long generatorId) {
+        return bookmarkRepository.findBookmarkIdByMemberAndGenerator(memberId, generatorId);
+    }
+}

--- a/src/main/java/Capstone/AutoScheduler/global/web/controller/BookmarkController.java
+++ b/src/main/java/Capstone/AutoScheduler/global/web/controller/BookmarkController.java
@@ -5,6 +5,7 @@ import Capstone.AutoScheduler.global.apiPayload.ApiResponse;
 import Capstone.AutoScheduler.global.converter.BookmarkConverter;
 import Capstone.AutoScheduler.global.domain.entity.Bookmark;
 import Capstone.AutoScheduler.global.service.BookmarkService.BookmarkCommandService;
+import Capstone.AutoScheduler.global.service.BookmarkService.BookmarkQueryService;
 import Capstone.AutoScheduler.global.web.dto.Bookmark.BookmarkResponseDTO;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -22,6 +23,7 @@ import org.springframework.web.bind.annotation.*;
 @Tag(name = "일정 생성기 북마크 API", description = "일정 생성기 북마크 추가/삭제/개수 조회 관련 API입니다.")
 public class BookmarkController {
     private final BookmarkCommandService bookmarkCommandService;
+    private final BookmarkQueryService bookmarkQueryService;
 
     // 북마크 추가
     @PostMapping("/add/{memberId}/{generatorId}")
@@ -35,12 +37,13 @@ public class BookmarkController {
     }
 
     // 북마크 삭제
-    @DeleteMapping("/delete/{bookmarkId}")
-    @Operation(summary = "북마크 삭제 API", description = "bookmarks, bookmarkId")
-    public ApiResponse<BookmarkResponseDTO.DeleteBookmarkResultDTO> deleteBookmark(
-            @PathVariable(name = "bookmarkId") Long bookmarkId
-    ) {
+    @DeleteMapping("/delete/{memberId}/{generatorId}")
+    @Operation(summary = "북마크 삭제 API", description = "memberId와 generatorId를 이용해 북마크를 삭제합니다.")
+    public ApiResponse<BookmarkResponseDTO.DeleteBookmarkResultDTO> deleteBookmark(@PathVariable Long memberId, @PathVariable Long generatorId) {
+        Long bookmarkId = bookmarkQueryService.findBookmarkIdByMemberAndGenerator(memberId, generatorId);
         bookmarkCommandService.deleteBookmark(bookmarkId);
+
         return ApiResponse.onSuccess(SuccessStatus.BOOKMARK_OK, BookmarkConverter.toDeleteBookmarkResultDTO(bookmarkId));
     }
+
 }


### PR DESCRIPTION
## #️⃣연관된 이슈
> #113

## 📝작업 내용
> 사용자가 일정 생성기 북마크를 삭제하는 API 기능 수정

## 🔎코드 설명 및 참고 사항
> - 사용자가 일정 생성기 북마크를 삭제하는 API 기능 수정
> - 현재는 bookmarkId를 pathvalue로 입력받아 삭제를 진행하지만, 사용자와 일정 생성기가 매핑되어있는 상태에서의 북마크 Id를 찾을 수 없는 문제가 발생하여, 사용자Id와 생성기Id를 pathvalue로 입력받으면 해당 매핑관계인 북마크를 삭제하는 방식으로 변경

## 💬리뷰 요구사항
>
