### PR TITLE
Refactor: 사용자별 북마크한 일정 생성기 리스트 조회 시 생성기 제작자의 이름을 가져오지 않고 조회한 사용자의 이름을 반환하는 오류 수정

### DIFF
--- a/src/main/java/Capstone/AutoScheduler/global/converter/MemberConverter.java
+++ b/src/main/java/Capstone/AutoScheduler/global/converter/MemberConverter.java
@@ -37,8 +37,8 @@ public class MemberConverter {
 
     public static MemberResponseDTO.BookmarkPreviewDTO toBookmarkPreviewDTO(Bookmark bookmark) {
         return MemberResponseDTO.BookmarkPreviewDTO.builder()
-                .memberId(bookmark.getMember().getMemberId())
-                .memberName(bookmark.getMember().getName())
+                .memberId(bookmark.getGenerator().getMember().getMemberId())
+                .memberName(bookmark.getGenerator().getMember().getName())
                 .bookmarkId(bookmark.getId())
                 .generatorId(bookmark.getGenerator().getGeneratorId())
                 .generatorTitle(bookmark.getGenerator().getGeneratorTitle())


### PR DESCRIPTION
## #️⃣연관된 이슈
> #113

## 📝작업 내용
> 사용자별 북마크한 일정 생성기 리스트 조회 시 생성기 제작자의 이름을 가져오지 않고 조회한 사용자의 이름을 반환하는 오류 수정

## 🔎코드 설명 및 참고 사항
> 사용자별 북마크한 일정 생성기 리스트 조회 시 생성기 제작자의 이름을 가져오지 않고 조회한 사용자의 이름을 반환하는 오류 수정

## 💬리뷰 요구사항
>
